### PR TITLE
Prefer 'env bash' shebang

### DIFF
--- a/cork.sh
+++ b/cork.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cork_script_path=$(realpath "$0")
 


### PR DESCRIPTION
'#!/bin/bash' on macOS explicitly refers to the old bash version 3.2.57.
'#!/usr/bin/env bash' will use new version if installed and falback to old one otherwise.