### PR TITLE
Add support for colorschemes

### DIFF
--- a/cork.sh
+++ b/cork.sh
@@ -111,7 +111,7 @@ setup-load-file() {
 
   folder="$install_path/$name"
 
-  find -L "$folder/repo" -type f -name '*\.kak' \
+  find -L "$folder/repo" -type f -name '*\.kak' ! -path "$folder/repo/colors/*" \
      | sed 's/.*/source "&"/' \
      > "$folder/load.kak"
 

--- a/cork.sh
+++ b/cork.sh
@@ -116,16 +116,7 @@ setup-load-file() {
      > "$folder/load.kak"
 
   if [ -d "$folder/repo/colors" ]; then
-    config_dir=$(kcr get -r -V config)
-    if [ -d "$config_dir" ]; then
-      colors_dir="$config_dir/colors"
-      if [ ! -d "$colors_dir" ]; then
-        mkdir $colors_dir
-      fi
-      if [ ! -d "$colors_dir/$name" ]; then
-        ln -s "$folder/repo/colors" "$colors_dir/$name"
-      fi
-    fi
+    echo "set -add global colorscheme_sources '$folder/repo/colors'" >> "$folder/load.kak"
   fi
 
   echo "trigger-user-hook cork-loaded=$name" >> "$folder/load.kak"

--- a/cork.sh
+++ b/cork.sh
@@ -115,6 +115,19 @@ setup-load-file() {
      | sed 's/.*/source "&"/' \
      > "$folder/load.kak"
 
+  if [ -d "$folder/repo/colors" ]; then
+    config_dir=$(kcr get -r -V config)
+    if [ -d "$config_dir" ]; then
+      colors_dir="$config_dir/colors"
+      if [ ! -d "$colors_dir" ]; then
+        mkdir $colors_dir
+      fi
+      if [ ! -d "$colors_dir/$name" ]; then
+        ln -s "$folder/repo/colors" "$colors_dir/$name"
+      fi
+    fi
+  fi
+
   echo "trigger-user-hook cork-loaded=$name" >> "$folder/load.kak"
 }
 
@@ -181,7 +194,7 @@ declare-option -hidden -docstring 'cork requires update' bool cork_requires_upda
 declare-option -hidden -docstring 'cork XDG_DATA_HOME path' str cork_xdg_data_home_path %sh(echo "${XDG_DATA_HOME:-$HOME/.local/share}")
 
 declare-option -docstring 'cork install path' str cork_install_path "%opt{cork_xdg_data_home_path}/kak/cork/plugins"
-  
+
 define-command -override cork -params 2..3 -docstring 'cork <name> <repository> [config]' %{
   set-option -add global cork_repository_map %arg{1} %arg{2}
   hook global -group cork-loaded User "cork-loaded=%arg{1}" %arg{3}
@@ -206,7 +219,7 @@ define-command -override cork-update %{
 }
 
 define-command -override cork-script -hidden -params 1.. %{
-  connect-program %opt{cork_script_path} %arg{@} 
+  connect-program %opt{cork_script_path} %arg{@}
 }
 
 define-command -override cork-interactive -hidden -params 1.. %{


### PR DESCRIPTION
Updated `cork.kak` to support colorschemes. This is achieved by checking for a `colors` directory in the plugin repo, then symlinking that folder to `~/.config/kak/colors`. This is definitely not the best way to do it, because it involves messing with the user's config directory, but it's the only option at the moment.

If https://github.com/mawww/kakoune/issues/4342 gets implemented, then it could be changed to simply invoking `declare-colorscheme` for each one.
(edit: upon further investigation, it would actually be more like `set -add colorscheme_directories "$folder/repo/colors"`)

Also updated the script to not automatically source `.kak` files in the `colors` directory.