### PR TITLE
Don't add any test.kak to load.kak

### DIFF
--- a/cork.sh
+++ b/cork.sh
@@ -131,7 +131,7 @@ setup-load-file() {
   folder="$install_path/$name"
   echo "echo -debug [cork]: Loading plugin $1..." > "$folder/load.kak"
 
-  find -L "$folder/repo" -type f -name '*\.kak' ! -path "$folder/repo/colors/*" \
+  find -L "$folder/repo" -type f -name '*\.kak' ! -name 'test\.kak' ! -path "$folder/repo/colors/*" \
      | sed 's/.*/source "&"/' \
      >> "$folder/load.kak"
 


### PR DESCRIPTION
Some plugins include `test.kak` file just for test purposes.
To name a few:

https://github.com/occivink/kakoune-sort-selections
https://github.com/occivink/kakoune-select-unique

adding `test.kak` to `load.kak` breaks things, so this PR is trying to fix this simply by skipping any `test.kak` file.