### PR TITLE
Ensure that mktemp -u does not fail with Busybox

### DIFF
--- a/cork.sh
+++ b/cork.sh
@@ -63,7 +63,7 @@ _confirm() {
 kak_ensure_session() {
   kak_session=${kak_session:-$KAKOUNE_SESSION}
   if [ -z "$kak_session" ]; then
-    kak_session=$(mktemp -u "cork-background-session-XXXX")
+    kak_session=$(mktemp -u "cork-background-session-XXXXXXXX")
     kak -d -s "$kak_session" > /dev/null &
     pid=$!
     trap "kill $pid" EXIT


### PR DESCRIPTION
When I tested cork.kak on an install of Alpine Linux with a bash shell and busybox coreutils installed, mktemp -u threw an error because there weren't at least six "X" characters. This PR fixes that. 